### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.2.0 — 2026-06-03
+
+- **Transfer entropy** (`entroscope.transfer`) — the first bivariate measure:
+  directional information flow `TE(X→Y)` (Schreiber 2000) with two estimators,
+  Kraskov KSG k-NN (default, no binning) and a binned histogram cross-check.
+  API: `compute`, `rolling`, `delta`, `plot`. A sample-size guard warns when the
+  data is too thin for the embedding dimension. Correctness is validated against
+  three independent authorities: the bivariate-Gaussian closed form, the
+  Kraskov-2004 analytic mutual information, and a hand-checked isolated embedding.
+- **Divergence** (`entroscope.divergence`) — distribution-vs-distribution
+  measures: `kl` (Kullback-Leibler, directional) and `js` (Jensen-Shannon,
+  symmetric, bounded `[0, 1]` bits), plus `plot`. Inputs are two raw samples,
+  binned over a shared range; KL uses epsilon smoothing to stay finite on empty
+  bins. Useful for data-drift detection (training vs production distributions).
+- **Fixed:** importing a measure no longer forces matplotlib's `Agg` backend
+  (issue #2). The library no longer mutates global matplotlib state on import, so
+  interactive plotting (e.g. `df.plot()` in a notebook) keeps working. Headless,
+  Docker, and CI users who want a guaranteed non-interactive backend should set
+  `MPLBACKEND=Agg` in their environment.
+- **Correlation-stability example** (`examples/correlation_stability.py`) —
+  entropy of a rolling correlation series as a regime-stability gauge, shipped
+  alongside a rolling-std baseline so the comparison stays honest.
+- New worked examples: `examples/information_flow.py` (directional transfer
+  entropy) and `examples/drift.py` (KL/JS distribution drift).
+
 ## 0.1.1 — 2026-06-01
 
 - Added a `LICENSE` file (MIT) and a `CONTRIBUTING.md` guide.

--- a/entroscope/__init__.py
+++ b/entroscope/__init__.py
@@ -13,7 +13,7 @@ from . import (
 )
 from .utils import plot
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __all__ = [
     "shannon",
     "permutation",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "entroscope"
-version = "0.1.1"
+version = "0.2.0"
 description = "The definitive entropy toolkit for time series data"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps `0.1.1 → 0.2.0` and adds the CHANGELOG entry. Ships the work merged since
0.1.1:

- **Transfer entropy** (`entroscope.transfer`) — KSG + binned estimators,
  validated against three analytic authorities (#1 / PR series).
- **Divergence** (`entroscope.divergence`) — KL + Jensen-Shannon for
  distribution drift (PR #3).
- **Fix:** no longer forces matplotlib's Agg backend on import (#2, PR #4).
- New examples: correlation stability, information flow, distribution drift.

No code changes here beyond the version bump + CHANGELOG — all features already
merged to master and green on CI.
